### PR TITLE
Allow alternative hostname color for ssh sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ Prompt is composed of several widgets that are displayed one after the other.
 
 Context prompt showing `user@hostname`.
 
-|             Variable              | Description                                                                                       |    Default     |
-| :-------------------------------: | :------------------------------------------------------------------------------------------------ | :------------: |
-|    `OHMYVIA_CONTEXT_HOSTNAME`     | Display hostname. Set to `partial` to print up to the first `.`. Set to `empty` to hide hostname. |     `full`     |
-| `OHMYVIA_CONTEXT_HOSTNAME_COLOR`  | Hostname background and foreground color.                                                         | `%B%F{white}`  |
-| `OHMYVIA_CONTEXT_SEPARATOR_COLOR` | `@` separator between the user and the hostname background and foreground color.                  | `%B%F{yellow}` |
-|   `OHMYVIA_CONTEXT_ROOT_COLOR`    | Root username background and foreground color.                                                    |  `%B%F{blue}`  |
-|   `OHMYVIA_CONTEXT_USER_COLOR`    | Non-root username background and foreground color.                                                |  `%B%F{red}`   |
+|               Variable               | Description                                                                                       |              Default              |
+| :----------------------------------: | :------------------------------------------------------------------------------------------------ | :-------------------------------: |
+|      `OHMYVIA_CONTEXT_HOSTNAME`      | Display hostname. Set to `partial` to print up to the first `.`. Set to `empty` to hide hostname. |              `full`               |
+|   `OHMYVIA_CONTEXT_HOSTNAME_COLOR`   | Hostname background and foreground color.                                                         |           `%B%F{white}`           |
+| `OHMYVIA_CONTEXT_HOSTNAME_COLOR_SSH` | Alternative hostname background and foreground color only applied on ssh sessions.                | `$OHMYVIA_CONTEXT_HOSTNAME_COLOR` |
+|  `OHMYVIA_CONTEXT_SEPARATOR_COLOR`   | `@` separator between the user and the hostname background and foreground color.                  |          `%B%F{yellow}`           |
+|     `OHMYVIA_CONTEXT_ROOT_COLOR`     | Root username background and foreground color.                                                    |           `%B%F{blue}`            |
+|     `OHMYVIA_CONTEXT_USER_COLOR`     | Non-root username background and foreground color.                                                |            `%B%F{red}`            |
 
 #### Working directory
 

--- a/functions/prompt_utils.zsh
+++ b/functions/prompt_utils.zsh
@@ -26,7 +26,14 @@ prompt_context () {
 	elif [[ $OHMYVIA_CONTEXT_HOSTNAME == 'partial' ]]; then
 		colorless_hostname="%m"
 	fi
-	local hostname="$OHMYVIA_CONTEXT_HOSTNAME_COLOR${colorless_hostname}%b%f"
+
+	# Set the color depending on whether we detect an ssh session or not
+	# If SSH_TTY is set and not empty, assume session is interactive and over ssh
+	if [[ -n $SSH_TTY ]]; then
+		local hostname="$OHMYVIA_CONTEXT_HOSTNAME_COLOR_SSH${colorless_hostname}%b%f"
+	else
+		local hostname="$OHMYVIA_CONTEXT_HOSTNAME_COLOR${colorless_hostname}%b%f"
+	fi
 
 	echo "${username}${separator}${hostname}"
 }

--- a/tests/utils.zunit
+++ b/tests/utils.zunit
@@ -29,6 +29,14 @@
 	assert $ZUNIT_TEST_VAR same_as "default_value"
 }
 
+@test 'Test set_default on non-set variable with copy' {
+	load $ZUNIT_LIB_DIR/utils.zsh
+
+	ZUNIT_TEST_VAR="test_value"
+	set_default ZUNIT_TEST_VAR_COPY "$ZUNIT_TEST_VAR"
+	assert $ZUNIT_TEST_VAR_COPY same_as "test_value"
+}
+
 @test 'Test set_default on already-set variable' {
 	load $ZUNIT_LIB_DIR/utils.zsh
 
@@ -46,11 +54,29 @@
 	assert $ZUNIT_TEST_VAR_COLOR same_as $ZUNIT_TEST_VAR_COLOR_WITNESS
 }
 
+@test 'Test set_default on /_COLOR$/ variable with copy' {
+	load $ZUNIT_LIB_DIR/utils.zsh
+
+	ZUNIT_TEST_VAR="test_value"
+	set_default       ZUNIT_TEST_VAR_COLOR         "$ZUNIT_TEST_VAR"
+	set_default_color ZUNIT_TEST_VAR_COLOR_WITNESS "test_value"
+	assert $ZUNIT_TEST_VAR_COLOR same_as $ZUNIT_TEST_VAR_COLOR_WITNESS
+}
+
 @test 'Test set_default on /_COLOR_.*$/ variable' {
 	load $ZUNIT_LIB_DIR/utils.zsh
 
 	set_default       ZUNIT_TEST_COLOR_VAR         "default_value"
 	set_default_color ZUNIT_TEST_COLOR_VAR_WITNESS "default_value"
+	assert $ZUNIT_TEST_COLOR_VAR same_as $ZUNIT_TEST_COLOR_VAR_WITNESS
+}
+
+@test 'Test set_default on /_COLOR_.*$/ variable with copy' {
+	load $ZUNIT_LIB_DIR/utils.zsh
+
+	ZUNIT_TEST_VAR="test_value"
+	set_default       ZUNIT_TEST_COLOR_VAR         "$ZUNIT_TEST_VAR"
+	set_default_color ZUNIT_TEST_COLOR_VAR_WITNESS "test_value"
 	assert $ZUNIT_TEST_COLOR_VAR same_as $ZUNIT_TEST_COLOR_VAR_WITNESS
 }
 

--- a/via.zsh-theme
+++ b/via.zsh-theme
@@ -23,11 +23,12 @@ source $OHMYVIA_INSTALLATION_PATH/functions/vcs_utils.zsh
 #################################################################################
 
 ## Context properties
-set_default OHMYVIA_CONTEXT_HOSTNAME        "full"
-set_default OHMYVIA_CONTEXT_HOSTNAME_COLOR  "%B%F{white}"
-set_default OHMYVIA_CONTEXT_SEPARATOR_COLOR "%B%F{yellow}"
-set_default OHMYVIA_CONTEXT_ROOT_COLOR      "%B%F{blue}"
-set_default OHMYVIA_CONTEXT_USER_COLOR      "%B%F{red}"
+set_default OHMYVIA_CONTEXT_HOSTNAME           "full"
+set_default OHMYVIA_CONTEXT_HOSTNAME_COLOR     "%B%F{white}"
+set_default OHMYVIA_CONTEXT_HOSTNAME_COLOR_SSH "$OHMYVIA_CONTEXT_HOSTNAME_COLOR"
+set_default OHMYVIA_CONTEXT_SEPARATOR_COLOR    "%B%F{yellow}"
+set_default OHMYVIA_CONTEXT_ROOT_COLOR         "%B%F{blue}"
+set_default OHMYVIA_CONTEXT_USER_COLOR         "%B%F{red}"
 
 # Dir properties
 set_default OHMYVIA_DIR_COLOR "%B%F{green}"


### PR DESCRIPTION
Closes https://github.com/badouralix/oh-my-via/issues/12

This introduce two new components : 

- a config variable `OHMYVIA_CONTEXT_HOSTNAME_COLOR_SSH` to set the hostname background and foreground color, but only for ssh sessions
- a pattern to copy default config variables, and zunit tests accordingly

I am not very happy with the new config variable name, but that should be good enough for now
For instance, maybe use `OHMYVIA_CONTEXT_HOSTNAME_COLOR_LOCAL` and `OHMYVIA_CONTEXT_HOSTNAME_COLOR_REMOTE`, although using the local color as the default for the remote color seems is bit odd
With the copy mechanism, it is possible to rename config variables with backward compatibility, in case I come up with a better name

See https://linux.die.net/man/1/ssh for details about `SSH_CONNECTION` and `SSH_TTY`
This page does not mention `SSH_CLIENT`...
I guess it is okay to check `SSH_TTY` as the prompt theme is only relevant when there is an actual prompt in interactive mode

About the `-n` in the if statement, see <https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html>
One potential issue is when `SSH_TTY` is set and not empty, but only filled with blanks and spaces
This is unlikely to happen, and even if it happens, it is probably the expected behavior to assume the session is over ssh